### PR TITLE
Fix de la UI despues de un update de los datos

### DIFF
--- a/client/src/components/table.mjs
+++ b/client/src/components/table.mjs
@@ -51,6 +51,7 @@ function render(table) {
 }
 
 function update(table, data) {
+    table.selectedRows = []
     table.data = data
     const $body = generateBody(table.header, table.data)
 


### PR DESCRIPTION
Si la tabla tenía alguna row seleccionada y se utiliza `table.update(newData)`,
la tabla queda inconsistente. La UI no muestra ninguna row seleccionada pero
`table.getSelectedRows()` retorna la row seleccionada.

Se fixea seteando la variable que almacena las rows seleccionadas con un
array vacio.